### PR TITLE
Fix null slugs

### DIFF
--- a/backend/memorial/deceased/migrations/0007_generate_slugs2.py
+++ b/backend/memorial/deceased/migrations/0007_generate_slugs2.py
@@ -1,0 +1,22 @@
+from deceased.models import Deceased
+from django.db import migrations
+
+
+def create_slugs_forward(apps, schema_editor):
+    for instance in Deceased.objects.all():
+        print("Generating slug for {}".format(instance))
+        instance.save(update_fields=['slug'])
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('deceased', '0006_auto_20210111_1805'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            create_slugs_forward,
+            reverse_code=migrations.RunPython.noop,
+        )
+    ]

--- a/backend/memorial/deceased/models.py
+++ b/backend/memorial/deceased/models.py
@@ -43,6 +43,10 @@ class Deceased(models.Model):
     )
     date_created = models.DateTimeField(auto_now=True)
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.__original_image = self.image
+
     def comments(self):
         return self.comment_set()
 
@@ -56,7 +60,8 @@ class Deceased(models.Model):
         ]
 
     def save(self, *args, **kwargs):
-        compress_and_assign_image(Deceased, self, field_name='image')
+        if self.pk is None or (self.__original_image != self.image):
+            compress_and_assign_image(Deceased, self, field_name='image')
         return super().save(*args, **kwargs)
 
     def __str__(self):


### PR DESCRIPTION
The previous migration fix left empty slugs. Now, don't skip the fields with issues, instead, add a better check on the image field to see if it's new.