### PR TITLE
Memoriam performance improvements

### DIFF
--- a/frontend/components/ChartMemoriam.vue
+++ b/frontend/components/ChartMemoriam.vue
@@ -183,7 +183,6 @@ export default {
             .attr('cy', (d, i) => d.y + dy)
             .attr('fill', '#DDDDDD')
             .attr('class', 'b-node')
-            .attr('style', 'will-change: transform;')
         }
       }
       return bG


### PR DESCRIPTION
Removed `will-change: transform` from the background dots styling which drastically improves performance when scrolling around the memoriam. 

The `will-change` property should only be used as a last resort in case of pre-existing performance issues, otherwise [it can cause more issues](https://developer.mozilla.org/en-US/docs/Web/CSS/will-change)