### PR TITLE
Hotfix: Update node to v16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup node env 🏗
         uses: actions/setup-node@v2.1.2
         with:
-          node-version: 14
+          node-version: 16
 
       - name: Cache node_modules 📦
         uses: actions/cache@v2
@@ -197,4 +197,4 @@ jobs:
 
       - name: Deploy to App Engine
         run: |
-          gcloud --quiet --project ${{ secrets.GCP_PROJECT }} app deploy frontend/app.yaml backend/backend.yaml dispatch.yaml
+          gcloud --quiet --project ${{ secrets.GCP_PROJECT }} app deploy frontend/app.yaml backend/backend.yaml dispatch.yaml --no-cache

--- a/frontend/app.yaml
+++ b/frontend/app.yaml
@@ -1,4 +1,4 @@
-runtime: nodejs12
+runtime: nodejs16
 service: default
 instance_class: F2
 
@@ -17,4 +17,4 @@ handlers:
     secure: always
 
 env_variables:
-  HOST: "0.0.0.0"
+  HOST: '0.0.0.0'


### PR DESCRIPTION
It seems there are now issues running node 12/14 in Google App Engine. 

I've updated the project to use Node 16 (rather than 18 or 20) because I think those versions may require more dependency updates.